### PR TITLE
Create worker pods with Dask Operator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,4 +32,4 @@ jobs:
       - name: Run tests
         env:
           KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
-        run: pytest
+        run: pytest dask_kubernetes/operator/tests/test_operator.py::test_simplecluster

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,4 +32,4 @@ jobs:
       - name: Run tests
         env:
           KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
-        run: pytest dask_kubernetes/operator/tests/test_operator.py::test_simplecluster
+        run: pytest

--- a/dask_kubernetes/operator/daskcluster.py
+++ b/dask_kubernetes/operator/daskcluster.py
@@ -177,7 +177,10 @@ async def daskcluster_create(spec, name, namespace, logger, **kwargs):
         namespace=namespace,
         body=data,
     )
-    logger.info(f"Worker group  in {namespace} is created")
+    logger.info(
+        f"A worker group has been created called {data['metadata']['name']} in {namespace} \
+        with the following config: {data['spec']}"
+    )
 
 
 @kopf.on.create("daskworkergroup")

--- a/dask_kubernetes/operator/daskcluster.py
+++ b/dask_kubernetes/operator/daskcluster.py
@@ -162,7 +162,10 @@ async def daskcluster_create(spec, name, namespace, logger, **kwargs):
         namespace=namespace,
         body=data,
     )
-    logger.info(f"Scheduler service in {namespace} is created")
+    logger.info(
+        f"A scheduler service has been created called {data['metadata']['name']} in {namespace} \
+        with the following config: {data['spec']}"
+    )
 
     data = build_worker_group_spec("default", spec.get("image"), spec.get("workers"))
     kopf.adopt(data)
@@ -179,10 +182,6 @@ async def daskcluster_create(spec, name, namespace, logger, **kwargs):
 
 @kopf.on.create("daskworkergroup")
 async def daskworkergroup_create(spec, name, namespace, logger, **kwargs):
-    logger.info(
-        f"A scheduler service has been created called {data['metadata']['name']} in {namespace} \
-        with the following config: {data['spec']}"
-    )
     api = kubernetes.client.CoreV1Api()
 
     scheduler = kubernetes.client.CustomObjectsApi().list_cluster_custom_object(

--- a/dask_kubernetes/operator/daskcluster.py
+++ b/dask_kubernetes/operator/daskcluster.py
@@ -105,6 +105,22 @@ def build_worker_pod_spec(name, namespace, image, n):
     }
 
 
+def build_worker_group_spec(name, image, workers):
+    return {
+        "apiVersion": "kubernetes.dask.org/v1",
+        "kind": "DaskWorkerGroup",
+        "metadata": {"name": f"{name}-worker-group"},
+        "spec": {
+            "image": image,
+            "workers": {
+                "replicas": workers["replicas"],
+                "resources": workers["resources"],
+                "env": workers["env"],
+            },
+        },
+    }
+
+
 async def wait_for_scheduler(cluster_name, namespace):
     api = kubernetes.client.CoreV1Api()
     watch = kubernetes.watch.Watch()
@@ -146,7 +162,41 @@ async def daskcluster_create(spec, name, namespace, logger, **kwargs):
         namespace=namespace,
         body=data,
     )
+    logger.info(f"Scheduler service in {namespace} is created")
+
+    data = build_worker_group_spec("default", spec.get("image"), spec.get("workers"))
+    kopf.adopt(data)
+    api = kubernetes.client.CustomObjectsApi()
+    worker_pods = api.create_namespaced_custom_object(
+        group="kubernetes.dask.org",
+        version="v1",
+        plural="daskworkergroups",
+        namespace=namespace,
+        body=data,
+    )
+    logger.info(f"Worker group  in {namespace} is created")
+
+
+@kopf.on.create("daskworkergroup")
+async def daskworkergroup_create(spec, name, namespace, logger, **kwargs):
     logger.info(
         f"A scheduler service has been created called {data['metadata']['name']} in {namespace} \
         with the following config: {data['spec']}"
     )
+    api = kubernetes.client.CoreV1Api()
+
+    scheduler = kubernetes.client.CustomObjectsApi().list_cluster_custom_object(
+        group="kubernetes.dask.org", version="v1", plural="daskclusters"
+    )
+    scheduler_name = scheduler["items"][0]["metadata"]["name"]
+
+    num_workers = spec["workers"]["replicas"]
+    for i in range(1, num_workers + 1):
+        data = build_worker_pod_spec(scheduler_name, namespace, spec.get("image"), i)
+        kopf.adopt(data)
+        worker_pod = api.create_namespaced_pod(
+            namespace=namespace,
+            body=data,
+        )
+    # await wait_for_scheduler(name, namespace)
+    logger.info(f"{num_workers} Worker pods in created in {namespace}")

--- a/dask_kubernetes/operator/daskcluster.py
+++ b/dask_kubernetes/operator/daskcluster.py
@@ -111,3 +111,4 @@ async def daskcluster_create(spec, name, namespace, logger, **kwargs):
         f"A scheduler service has been created called {data['metadata']['name']} in {namespace} \
         with the following config: {data['spec']}"
     )
+#

--- a/dask_kubernetes/operator/tests/resources/simplecluster.yaml
+++ b/dask_kubernetes/operator/tests/resources/simplecluster.yaml
@@ -16,3 +16,7 @@ spec:
     # affinity: null
     # tolerations: null
     # serviceAccountName: null
+  workers:
+    replicas: 3
+    resources: {}
+    env: {}

--- a/dask_kubernetes/operator/tests/resources/simpleworkergroup.yaml
+++ b/dask_kubernetes/operator/tests/resources/simpleworkergroup.yaml
@@ -6,3 +6,12 @@ spec:
   imagePullSecrets: null
   image: "daskdev/dask:latest"
   imagePullPolicy: "IfNotPresent"
+  workers:
+    replicas: 2
+    resources: {}
+    env: {}
+    # nodeSelector: null
+    # securityContext: null
+    # affinity: null
+    # tolerations: null
+    # serviceAccountName: null

--- a/dask_kubernetes/operator/tests/resources/simpleworkergroup.yaml
+++ b/dask_kubernetes/operator/tests/resources/simpleworkergroup.yaml
@@ -1,7 +1,7 @@
 apiVersion: kubernetes.dask.org/v1
 kind: DaskWorkerGroup
 metadata:
-  name: simple-worker-group
+  name: additional-worker-group
 spec:
   imagePullSecrets: null
   image: "daskdev/dask:latest"

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -74,7 +74,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             #     "logs", scheduler_pod_name
             # ):
             #     await asyncio.sleep(0.1)
-            await asyncio.sleep(50)
+            await asyncio.sleep(40)
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -74,7 +74,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             #     "logs", scheduler_pod_name
             # ):
             #     await asyncio.sleep(0.1)
-            await asyncio.sleep(30)
+            await asyncio.sleep(60)
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
                     f"{cluster_name}:{port}", asynchronous=True

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -60,14 +60,13 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
         async with gen_cluster() as cluster_name:
             # TODO test our cluster here
             scheduler_pod_name = "simple-cluster-scheduler"
-            scheduler_service_name = "simple-cluster"
             worker_pod_name = "simple-cluster-worker-1"
-            # while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
-            #     await asyncio.sleep(0.1)
-            # while scheduler_service_name not in k8s_cluster.kubectl("get", "svc"):
-            #     await asyncio.sleep(0.1)
-            # while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
-            #     await asyncio.sleep(0.1)
+            while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
+                await asyncio.sleep(0.1)
+            while cluster_name not in k8s_cluster.kubectl("get", "svc"):
+                await asyncio.sleep(0.1)
+            while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
+                await asyncio.sleep(0.1)
 
             from dask.distributed import Client
 

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -70,10 +70,10 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                 await asyncio.sleep(0.1)
             while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
-            while "Scheduler at:" not in k8s_cluster.kubectl(
-                "logs", scheduler_pod_name
-            ):
-                await asyncio.sleep(0.1)
+            # while "Scheduler at:" not in k8s_cluster.kubectl(
+            #     "logs", scheduler_pod_name
+            # ):
+            #     await asyncio.sleep(0.1)
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -55,20 +55,21 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(180)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
             # TODO test our cluster here
+            await asyncio.sleep(60)
             scheduler_pod_name = "simple-cluster-scheduler"
             worker_pod_name = "simple-cluster-worker-1"
-            # while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
-            #     await asyncio.sleep(0.1)
-            # while cluster_name not in k8s_cluster.kubectl("get", "svc"):
-            #     await asyncio.sleep(0.1)
-            # while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
-            #     await asyncio.sleep(0.1)
+            while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
+                await asyncio.sleep(0.1)
+            while cluster_name not in k8s_cluster.kubectl("get", "svc"):
+                await asyncio.sleep(0.1)
+            while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
+                await asyncio.sleep(0.1)
 
             await asyncio.sleep(60)
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -61,7 +61,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
             # TODO test our cluster here
-            # await asyncio.sleep(60)
+            await asyncio.sleep(60)
             scheduler_pod_name = "simple-cluster-scheduler"
             worker_pod_name = "simple-cluster-worker-1"
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -69,7 +69,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             #     await asyncio.sleep(0.1)
             # while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
             #     await asyncio.sleep(0.1)
-
+            await asyncio.sleep(60)
             while "Scheduler at:" not in k8s_cluster.kubectl(
                 "logs", scheduler_pod_name
             ):

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -55,7 +55,7 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-# @pytest.mark.timeout(180)
+@pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -7,7 +7,7 @@ import os.path
 
 from kopf.testing import KopfRunner
 
-from dask.distributed import Client
+# from dask.distributed import Client
 
 DIR = pathlib.Path(__file__).parent.absolute()
 
@@ -55,13 +55,13 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-@pytest.mark.timeout(180)
+@pytest.mark.timeout(60)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
             # TODO test our cluster here
-            await asyncio.sleep(60)
+            # await asyncio.sleep(60)
             scheduler_pod_name = "simple-cluster-scheduler"
             worker_pod_name = "simple-cluster-worker-1"
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
@@ -74,17 +74,17 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             #     "logs", scheduler_pod_name
             # ):
             #     await asyncio.sleep(0.1)
-            await asyncio.sleep(60)
-            with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
-                async with Client(
-                    f"{cluster_name}:{port}", asynchronous=True
-                ) as client:
-                    await client.wait_for_workers(2)
-                    # Ensure that inter-worker communication works well
-                    futures = client.map(lambda x: x + 1, range(10))
-                    total = client.submit(sum, futures)
-                    assert (await total) == sum(map(lambda x: x + 1, range(10)))
-                    assert all((await client.has_what()).values())
+            # await asyncio.sleep(60)
+            # with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
+            #     async with Client(
+            #         f"{cluster_name}:{port}", asynchronous=True
+            #     ) as client:
+            #         await client.wait_for_workers(2)
+            #         # Ensure that inter-worker communication works well
+            #         futures = client.map(lambda x: x + 1, range(10))
+            #         total = client.submit(sum, futures)
+            #         assert (await total) == sum(map(lambda x: x + 1, range(10)))
+            #         assert all((await client.has_what()).values())
             assert cluster_name
 
     assert "A DaskCluster has been created" in runner.stdout

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -61,15 +61,15 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
             # TODO test our cluster here
+            await asyncio.sleep(60)
             scheduler_pod_name = "simple-cluster-scheduler"
             worker_pod_name = "simple-cluster-worker-1"
-            # while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
-            #     await asyncio.sleep(0.1)
-            # while cluster_name not in k8s_cluster.kubectl("get", "svc"):
-            #     await asyncio.sleep(0.1)
-            # while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
-            #     await asyncio.sleep(0.1)
-            await asyncio.sleep(60)
+            while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
+                await asyncio.sleep(0.1)
+            while cluster_name not in k8s_cluster.kubectl("get", "svc"):
+                await asyncio.sleep(0.1)
+            while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
+                await asyncio.sleep(0.1)
             while "Scheduler at:" not in k8s_cluster.kubectl(
                 "logs", scheduler_pod_name
             ):

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -7,7 +7,7 @@ import os.path
 
 from kopf.testing import KopfRunner
 
-# from dask.distributed import Client
+from dask.distributed import Client
 
 DIR = pathlib.Path(__file__).parent.absolute()
 
@@ -55,7 +55,7 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-# @pytest.mark.timeout(60)
+@pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
@@ -70,21 +70,21 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                 await asyncio.sleep(0.1)
             while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
-            while "Scheduler at:" not in k8s_cluster.kubectl(
-                "logs", scheduler_pod_name
-            ):
-                await asyncio.sleep(0.1)
-            # await asyncio.sleep(60)
-            # with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
-            #     async with Client(
-            #         f"{cluster_name}:{port}", asynchronous=True
-            #     ) as client:
-            #         await client.wait_for_workers(2)
-            #         # Ensure that inter-worker communication works well
-            #         futures = client.map(lambda x: x + 1, range(10))
-            #         total = client.submit(sum, futures)
-            #         assert (await total) == sum(map(lambda x: x + 1, range(10)))
-            #         assert all((await client.has_what()).values())
+            # while "Scheduler at:" not in k8s_cluster.kubectl(
+            #     "logs", scheduler_pod_name
+            # ):
+            #     await asyncio.sleep(0.1)
+            await asyncio.sleep(30)
+            with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
+                async with Client(
+                    f"{cluster_name}:{port}", asynchronous=True
+                ) as client:
+                    await client.wait_for_workers(2)
+                    # Ensure that inter-worker communication works well
+                    futures = client.map(lambda x: x + 1, range(10))
+                    total = client.submit(sum, futures)
+                    assert (await total) == sum(map(lambda x: x + 1, range(10)))
+                    assert all((await client.has_what()).values())
             assert cluster_name
 
     assert "A DaskCluster has been created" in runner.stdout

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -55,7 +55,7 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-@pytest.mark.timeout(180)
+# @pytest.mark.timeout(180)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
@@ -74,7 +74,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             #     "logs", scheduler_pod_name
             # ):
             #     await asyncio.sleep(0.1)
-            await asyncio.sleep(60)
+            # await asyncio.sleep(60)
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -74,7 +74,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             #     "logs", scheduler_pod_name
             # ):
             #     await asyncio.sleep(0.1)
-            await asyncio.sleep(60)
+            await asyncio.sleep(50)
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -55,7 +55,7 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-@pytest.mark.timeout(60)
+# @pytest.mark.timeout(60)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
@@ -70,10 +70,10 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                 await asyncio.sleep(0.1)
             while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
-            # while "Scheduler at:" not in k8s_cluster.kubectl(
-            #     "logs", scheduler_pod_name
-            # ):
-            #     await asyncio.sleep(0.1)
+            while "Scheduler at:" not in k8s_cluster.kubectl(
+                "logs", scheduler_pod_name
+            ):
+                await asyncio.sleep(0.1)
             # await asyncio.sleep(60)
             # with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
             #     async with Client(

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -60,12 +60,17 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
         async with gen_cluster() as cluster_name:
             # TODO test our cluster here
             scheduler_pod_name = "simple-cluster-scheduler"
-            # scheduler_service_name = "simple-cluster"
+            scheduler_service_name = "simple-cluster"
+            worker_pod_name = "simple-cluster-worker-1"
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
+                await asyncio.sleep(0.1)
+            while scheduler_pod_name not in k8s_cluster.kubectl("get", "svc"):
+                await asyncio.sleep(0.1)
+            while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
             assert cluster_name
 
     assert "A DaskCluster has been created" in runner.stdout
     assert "A scheduler pod has been created" in runner.stdout
-    assert "A scheduler service has been created" in runner.stdout
+    assert "A worker group has been created" in runner.stdout
     # TODO test that the cluster has been cleaned up

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -75,7 +75,9 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             # ):
             #     await asyncio.sleep(0.1)
             # await asyncio.sleep(60)
-            with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
+            with k8s_cluster.port_forward(
+                f"service/{cluster_name}", 8786, localhost=8786
+            ) as port:
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True
                 ) as client:

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -75,11 +75,9 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             # ):
             #     await asyncio.sleep(0.1)
             # await asyncio.sleep(60)
-            with k8s_cluster.port_forward(
-                f"service/{cluster_name}", 8786, localhost=8786
-            ) as port:
+            with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
-                    f"tcp://localhost:{port}", asynchronous=True
+                    f"{cluster_name}:{port}", asynchronous=True
                 ) as client:
                     await client.wait_for_workers(2)
                     # Ensure that inter-worker communication works well

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -77,7 +77,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             await asyncio.sleep(60)
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
-                    f"{cluster_name}:{port}", asynchronous=True
+                    f"tcp://localhost:{port}", asynchronous=True
                 ) as client:
                     await client.wait_for_workers(2)
                     # Ensure that inter-worker communication works well

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -55,7 +55,7 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(180)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
@@ -74,6 +74,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             #     "logs", scheduler_pod_name
             # ):
             #     await asyncio.sleep(0.1)
+            await asyncio.sleep(60)
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -55,23 +55,24 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-@pytest.mark.timeout(180)
+@pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
             # TODO test our cluster here
-            await asyncio.sleep(60)
-            scheduler_pod_name = "simple-cluster-scheduler"
-            worker_pod_name = "simple-cluster-worker-1"
-            while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
-                await asyncio.sleep(0.1)
-            while cluster_name not in k8s_cluster.kubectl("get", "svc"):
-                await asyncio.sleep(0.1)
-            while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
-                await asyncio.sleep(0.1)
+            # await asyncio.sleep(60)
+            # scheduler_pod_name = "simple-cluster-scheduler"
+            # worker_pod_name = "simple-cluster-worker-1"
+            # while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
+            #     await asyncio.sleep(0.1)
+            # while cluster_name not in k8s_cluster.kubectl("get", "svc"):
+            #     await asyncio.sleep(0.1)
+            # while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
+            #     await asyncio.sleep(0.1)
 
-            await asyncio.sleep(60)
+            while "A scheduler pod has been created" not in runner.stdout:
+                await asyncio.sleep(0.1)
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -61,9 +61,8 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
             # TODO test our cluster here
-            # await asyncio.sleep(60)
-            # scheduler_pod_name = "simple-cluster-scheduler"
-            # worker_pod_name = "simple-cluster-worker-1"
+            scheduler_pod_name = "simple-cluster-scheduler"
+            worker_pod_name = "simple-cluster-worker-1"
             # while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
             #     await asyncio.sleep(0.1)
             # while cluster_name not in k8s_cluster.kubectl("get", "svc"):
@@ -71,7 +70,9 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             # while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
             #     await asyncio.sleep(0.1)
 
-            while "A scheduler pod has been created" not in runner.stdout:
+            while "Scheduler at:" not in k8s_cluster.kubectl(
+                "logs", scheduler_pod_name
+            ):
                 await asyncio.sleep(0.1)
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -7,6 +7,8 @@ import os.path
 
 from kopf.testing import KopfRunner
 
+from dask.distributed import Client
+
 DIR = pathlib.Path(__file__).parent.absolute()
 
 
@@ -53,7 +55,7 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
@@ -61,15 +63,14 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             # TODO test our cluster here
             scheduler_pod_name = "simple-cluster-scheduler"
             worker_pod_name = "simple-cluster-worker-1"
-            while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
-                await asyncio.sleep(0.1)
-            while cluster_name not in k8s_cluster.kubectl("get", "svc"):
-                await asyncio.sleep(0.1)
-            while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
-                await asyncio.sleep(0.1)
+            # while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
+            #     await asyncio.sleep(0.1)
+            # while cluster_name not in k8s_cluster.kubectl("get", "svc"):
+            #     await asyncio.sleep(0.1)
+            # while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
+            #     await asyncio.sleep(0.1)
 
-            from dask.distributed import Client
-
+            await asyncio.sleep(60)
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -82,7 +82,6 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                     futures = client.map(lambda x: x + 1, range(10))
                     total = client.submit(sum, futures)
                     assert (await total) == sum(map(lambda x: x + 1, range(10)))
-                    assert all((await client.has_what()).values())
             assert cluster_name
 
     assert "A DaskCluster has been created" in runner.stdout

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -55,13 +55,13 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-@pytest.mark.timeout(120)
+# @pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
             # TODO test our cluster here
-            # await asyncio.sleep(60)
+            await asyncio.sleep(60)
             scheduler_pod_name = "simple-cluster-scheduler"
             worker_pod_name = "simple-cluster-worker-1"
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -61,7 +61,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
             # TODO test our cluster here
-            await asyncio.sleep(60)
+            # await asyncio.sleep(60)
             scheduler_pod_name = "simple-cluster-scheduler"
             worker_pod_name = "simple-cluster-worker-1"
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -74,7 +74,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             #     "logs", scheduler_pod_name
             # ):
             #     await asyncio.sleep(0.1)
-            await asyncio.sleep(40)
+            await asyncio.sleep(35)
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -74,7 +74,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             #     "logs", scheduler_pod_name
             # ):
             #     await asyncio.sleep(0.1)
-            # await asyncio.sleep(60)
+            await asyncio.sleep(60)
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
                     f"{cluster_name}:{port}", asynchronous=True

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -55,7 +55,7 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(180)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -55,26 +55,24 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-# @pytest.mark.timeout(120)
+@pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
-            # TODO test our cluster here
-            # await asyncio.sleep(60)
             scheduler_pod_name = "simple-cluster-scheduler"
             worker_pod_name = "simple-cluster-worker-1"
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
+                await asyncio.sleep(0.1)
+            while "Running" not in k8s_cluster.kubectl(
+                "get", "pods", scheduler_pod_name
+            ):
                 await asyncio.sleep(0.1)
             while cluster_name not in k8s_cluster.kubectl("get", "svc"):
                 await asyncio.sleep(0.1)
             while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
-            # while "Scheduler at:" not in k8s_cluster.kubectl(
-            #     "logs", scheduler_pod_name
-            # ):
-            #     await asyncio.sleep(0.1)
-            await asyncio.sleep(35)
+
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True


### PR DESCRIPTION
As a part of https://github.com/dask/dask-kubernetes/pull/392, the Dask Operator needs to create/update/delete pods and things on Kubernetes whenever we create our custom resources. This PR is concerned with creating and deleting the worker pods when we create or delete a DaskWorkerGroup resource, respectively.